### PR TITLE
Fixes for online tournaments

### DIFF
--- a/Mimir/APIDOC.md
+++ b/Mimir/APIDOC.md
@@ -475,6 +475,29 @@ Exceptions:
 * _InvalidParametersException_ 
 * _AuthFailedException_ 
 
+### generateSwissSeating
+Parameters:
+* **$eventId** (_int_) 
+
+Returns: _array_ a multidimensional numerically indexed array
+
+Exceptions:
+* _AuthFailedException_ 
+* _InvalidParametersException_ 
+
+### makeIntervalSeating
+Parameters:
+* **$eventId** (_int_) 
+* **$step** (_int_) 
+
+Returns: _bool_ 
+
+Exceptions:
+* _AuthFailedException_ 
+* _DatabaseException_ 
+* _InvalidParametersException_ 
+* _InvalidUserException_ 
+
 ### makeManualSeating
 Parameters:
 * **$eventId** (_int_) 

--- a/Mimir/config/routes.php
+++ b/Mimir/config/routes.php
@@ -79,9 +79,10 @@ return [
     'getPlayer'          => ['PlayersController', 'get'],
     'getEverybody'       => ['PlayersController', 'getAll'], // TODO: get rid
 
-    'getCurrentSeating'   => ['EventsController', 'getCurrentSeating'],
-    'makeShuffledSeating' => ['SeatingController', 'makeShuffledSeating'],
-    'makeSwissSeating'    => ['SeatingController', 'makeSwissSeating'],
-    'makeIntervalSeating' => ['SeatingController', 'makeIntervalSeating'],
-    'makeManualSeating'   => ['SeatingController', 'makeManualSeating'],
+    'getCurrentSeating'    => ['EventsController', 'getCurrentSeating'],
+    'makeShuffledSeating'  => ['SeatingController', 'makeShuffledSeating'],
+    'makeSwissSeating'     => ['SeatingController', 'makeSwissSeating'],
+    'generateSwissSeating' => ['SeatingController', 'generateSwissSeating'],
+    'makeIntervalSeating'  => ['SeatingController', 'makeIntervalSeating'],
+    'makeManualSeating'    => ['SeatingController', 'makeManualSeating'],
 ];

--- a/Mimir/config/rulesets/online.php
+++ b/Mimir/config/rulesets/online.php
@@ -1,0 +1,74 @@
+<?php
+/*  Mimir: mahjong games storage
+ *  Copyright (C) 2016  o.klimenko aka ctizen
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace Mimir;
+
+require_once __DIR__ . '/../../src/Ruleset.php';
+
+/**
+ * Class RulesetOnline
+ * Describes most popular row3-column2 tenhou rules + different results scores
+ * @package Mimir
+ */
+class RulesetOnline extends Ruleset
+{
+    protected static $_title = 'online';
+    protected static $_ruleset = [
+        'tenboDivider'          => 1,
+        'ratingDivider'         => 1,
+        'startRating'           => 0,
+        'oka'                   => 20,
+        'startPoints'           => 25000,
+        'subtractStartPoints'   => true,
+        'riichiGoesToWinner'    => true,
+        'extraChomboPayments'   => false,
+        'chomboPenalty'         => 0,
+        'withAtamahane'         => false,
+        'withAbortives'         => true,
+        'withKuitan'            => true,
+        'withKazoe'             => true,
+        'withButtobi'           => true,
+        'withMultiYakumans'     => true,
+        'withNagashiMangan'     => true,
+        'withKiriageMangan'     => false,
+        'tonpuusen'             => false,
+        'gameExpirationTime'    => 24, // hours, to cover JST difference
+        'yakuWithPao'           => [Y_DAISANGEN, Y_DAISUUSHII, Y_SUUKANTSU],
+        'withLeadingDealerGameOver' => true,
+        'timerPolicy'           => 'none',
+        'yellowZone'            => 0,
+        'redZone'               => 0,
+        'penaltyStep'           => 0,
+        'maxPenalty'            => 0,
+        'minPenalty'            => 0,
+        'uma' => [
+            1 => 15000,
+            2 => 5000,
+            3 => -5000,
+            4 => -15000
+        ],
+        'replacementPlayerFixedPoints' => false,
+        'replacementPlayerOverrideUma' => false
+    ];
+
+    public function allowedYaku()
+    {
+        return YakuMap::listExcept([
+            Y_OPENRIICHI
+        ]);
+    }
+}

--- a/Mimir/config/rulesets/online.php
+++ b/Mimir/config/rulesets/online.php
@@ -41,9 +41,9 @@ class RulesetOnline extends Ruleset
         'withAbortives'         => true,
         'withKuitan'            => true,
         'withKazoe'             => true,
-        'withButtobi'           => true,
+        'withButtobi'           => false,
         'withMultiYakumans'     => true,
-        'withNagashiMangan'     => true,
+        'withNagashiMangan'     => false,
         'withKiriageMangan'     => false,
         'tonpuusen'             => false,
         'gameExpirationTime'    => 24, // hours, to cover JST difference

--- a/Mimir/config/rulesets/online.php
+++ b/Mimir/config/rulesets/online.php
@@ -32,7 +32,7 @@ class RulesetOnline extends Ruleset
         'ratingDivider'         => 1,
         'startRating'           => 0,
         'oka'                   => 20,
-        'startPoints'           => 25000,
+        'startPoints'           => 30000,
         'subtractStartPoints'   => true,
         'riichiGoesToWinner'    => true,
         'extraChomboPayments'   => false,

--- a/Mimir/config/rulesets/online.php
+++ b/Mimir/config/rulesets/online.php
@@ -31,7 +31,7 @@ class RulesetOnline extends Ruleset
         'tenboDivider'          => 1,
         'ratingDivider'         => 1,
         'startRating'           => 0,
-        'oka'                   => 20,
+        'oka'                   => 0,
         'startPoints'           => 30000,
         'subtractStartPoints'   => true,
         'riichiGoesToWinner'    => true,

--- a/Mimir/src/controllers/Events.php
+++ b/Mimir/src/controllers/Events.php
@@ -277,6 +277,8 @@ class EventsController extends Controller
         }
 
         $rules = $event[0]->getRuleset();
+        # we don't need to display add replay button to the online tournaments
+        $hideAddReplayButton = $rules->title() == 'online';
         $data = [
             'allowedYaku'         => array_values($rules->allowedYaku()),
             'startPoints'         => $rules->startPoints(),
@@ -322,7 +324,8 @@ class EventsController extends Controller
             'subtractStartPoints' => $rules->subtractStartPoints(),
             'seriesLength'        => $event[0]->getSeriesLength(),
             'gamesStatus'         => $event[0]->getGamesStatus(),
-            'hideResults'         => (bool)$event[0]->getHideResults()
+            'hideResults'         => (bool)$event[0]->getHideResults(),
+            'hideAddReplayButton' => $hideAddReplayButton
         ];
 
         $this->_log->addInfo('Successfully received config for event id# ' . $eventId);

--- a/Mimir/src/controllers/Seating.php
+++ b/Mimir/src/controllers/Seating.php
@@ -85,6 +85,27 @@ class SeatingController extends Controller
     }
 
     /**
+     * Generate a new swiss seating.
+     * It is here because of online tournaments.
+     *
+     * @param int $eventId
+     * @throws AuthFailedException
+     * @throws InvalidParametersException
+     * @return array a multidimensional numerically indexed array
+     */
+    public function generateSwissSeating($eventId)
+    {
+        $this->_checkIfAllowed($eventId);
+        $this->_log->addInfo('Generating new swiss seating for event #' . $eventId);
+
+        list ($playersMap, $tables) = $this->_getData($eventId);
+        $seating = array_chunk(array_keys(Seating::swissSeating($playersMap, $tables)), 4);
+
+        $this->_log->addInfo('Generated new swiss seating for event #' . $eventId);
+        return $seating;
+    }
+
+    /**
      * Make new manual seating.
      * This will also start games immediately if timer is not used.
      *
@@ -202,12 +223,12 @@ class SeatingController extends Controller
     protected function _getData($eventId)
     {
         $playersMap = [];
-        
+
         $event = EventPrimitive::findById($this->_db, [$eventId]);
         if (empty($event)) {
             throw new InvalidParametersException('Event id#' . $eventId . ' not found in DB');
         }
-        
+
         $histories = PlayerHistoryPrimitive::findLastByEvent($this->_db, $eventId);
         if (!empty($histories)) {
             foreach ($histories as $h) {

--- a/Mimir/src/helpers/SessionState.php
+++ b/Mimir/src/helpers/SessionState.php
@@ -259,6 +259,15 @@ class SessionState
     }
 
     /**
+     * @return SessionState
+     */
+    public function setScores($scores)
+    {
+        $this->_scores = $scores;
+        return $this;
+    }
+
+    /**
      * @return \int[]
      */
     public function getPenalties()

--- a/Mimir/src/helpers/onlineLog/Parser.php
+++ b/Mimir/src/helpers/onlineLog/Parser.php
@@ -326,10 +326,6 @@ class OnlineParser
     protected function _tokenGO(\XMLReader $reader, SessionPrimitive $session)
     {
         $eventLobby = $session->getEvent()->getLobbyId();
-        // we didn't set lobby restriction in the config
-        if (!$eventLobby) {
-            return;
-        }
 
         $lobby = $reader->getAttribute('lobby');
         if ($eventLobby != $lobby) {

--- a/Mimir/src/helpers/onlineLog/Parser.php
+++ b/Mimir/src/helpers/onlineLog/Parser.php
@@ -325,8 +325,13 @@ class OnlineParser
 
     protected function _tokenGO(\XMLReader $reader, SessionPrimitive $session)
     {
-        $lobby = $reader->getAttribute('lobby');
         $eventLobby = $session->getEvent()->getLobbyId();
+        // we didn't set lobby restriction in the config
+        if (!$eventLobby) {
+            return;
+        }
+
+        $lobby = $reader->getAttribute('lobby');
         if ($eventLobby != $lobby) {
             throw new ParseException('Provided replay doesn\'t belong to the event lobby ' . $eventLobby);
         }

--- a/Mimir/src/models/OnlineSession.php
+++ b/Mimir/src/models/OnlineSession.php
@@ -43,7 +43,7 @@ class OnlineSessionModel extends Model
             throw new InvalidParametersException('Event id#' . $eventId . ' not found in DB');
         }
         $event = $event[0];
-        
+
         if (!$event->getIsOnline()) {
             throw new InvalidParametersException('Unable to add online game to event that is not online.');
         }
@@ -80,13 +80,14 @@ class OnlineSessionModel extends Model
         }
         $success = $success && $session->prefinish();
 
-        $calculatedScore = $session->getCurrentState()->getScores();
-        if (array_diff($calculatedScore, $originalScore) !== []
-            || array_diff($originalScore, $calculatedScore) !== []) {
-            throw new ParseException("Calculated scores do not match with given ones: " . PHP_EOL
-                . print_r($originalScore, 1) . PHP_EOL
-                . print_r($calculatedScore, 1), 225);
-        }
+        // let's disable it for now
+//        $calculatedScore = $session->getCurrentState()->getScores();
+//        if (array_diff($calculatedScore, $originalScore) !== []
+//            || array_diff($originalScore, $calculatedScore) !== []) {
+//            throw new ParseException("Calculated scores do not match with given ones: " . PHP_EOL
+//                . print_r($originalScore, 1) . PHP_EOL
+//                . print_r($calculatedScore, 1), 225);
+//        }
 
         return $success;
     }

--- a/Mimir/src/models/OnlineSession.php
+++ b/Mimir/src/models/OnlineSession.php
@@ -73,11 +73,17 @@ class OnlineSessionModel extends Model
 
         list($success, $originalScore, $rounds/*, $debug*/) = $parser->parseToSession($session, $gameContent);
         $success = $success && $session->save();
+
         /** @var MultiRoundPrimitive|RoundPrimitive $round */
         foreach ($rounds as $round) {
             $round->setSession($session);
             $success = $success && $round->save();
         }
+
+        // ignore calculated scores
+        // and set scores that we got from replay
+        $session->getCurrentState()->setScores($originalScore);
+
         $success = $success && $session->prefinish();
 
         // let's disable it for now

--- a/Rheda/src/Controller.php
+++ b/Rheda/src/Controller.php
@@ -160,7 +160,8 @@ abstract class Controller
                 'eventTitle' => $this->_rules->eventTitle(),
                 'pageTitle' => $pageTitle,
                 'content' => $templateEngine->render($add . $this->_mainTemplate, $context),
-                'isLoggedIn' => $this->_adminAuthOk()
+                'isLoggedIn' => $this->_adminAuthOk(),
+                'hideAddReplayButton' => $this->_rules->hideAddReplayButton()
             ]);
         }
 

--- a/Rheda/src/helpers/Config.php
+++ b/Rheda/src/helpers/Config.php
@@ -46,6 +46,7 @@ class Config
     protected $_seriesLength = 0;
     protected $_gamesStatus = false;
     protected $_hideResults = false;
+    protected $_hideAddReplayButton = false;
 
     public static function fromRaw($arr)
     {
@@ -349,7 +350,6 @@ class Config
     {
         return $this->_seriesLength;
     }
-
     /**
      * @return bool
      */
@@ -363,5 +363,12 @@ class Config
     public function hideResults()
     {
         return $this->_hideResults;
+    }
+    /**
+     * @return bool
+     */
+    public function hideAddReplayButton()
+    {
+        return $this->_hideAddReplayButton;
     }
 }

--- a/Rheda/src/templates/Layout.handlebars
+++ b/Rheda/src/templates/Layout.handlebars
@@ -40,8 +40,10 @@
         <ul class="navbar-nav">
             <li class="nav-item">{{#a class='nav-link' href='/last/'}}{{_t 'Recent games'}}{{/a}}</li>
             <li class="nav-item">{{#a class='nav-link' href='/stat/'}}{{_t 'Rating table'}}{{/a}}</li>
-            {{#isOnline}}
+            {{#isOnline }}
+              {{^hideAddReplayButton}}
                 <li class="nav-item">{{#a class='nav-link' href='/add-online/'}}{{_t 'Add online game' }}{{/a}}</li>
+              {{/hideAddReplayButton}}
             {{/isOnline}}
             {{#isLoggedIn}}
                 <li class="nav-item dropdown">


### PR DESCRIPTION
Список изменений:

1. Добавил рулсет для онлайн турниров. В нём сочетаются правила с тенхи + подсчёт очков как в оффлайн турнирах.
2. Убрал проверку на лобби реплея, если у евента не стоит лобби.
3. Добавил API для получения швейцарской рассадки.
4. Скрыл кнопку "Добавить реплей" для онлайн турнира. Новый флаг в ивент не сдал добавлять, их и так уже много. Сейчас кнопка не будет показана если тип стоит рулсет = online.
5. Теперь в финальные очки для онлайн игр заносятся очки пришедшие из реплея, а не очки которые насчитал пантеон. На данный момент есть три бага, когда пантеон считает очки не так как их считает тенха:
https://pantheon.myjetbrains.com/youtrack/issue/PNTN-227
https://pantheon.myjetbrains.com/youtrack/issue/PNTN-69
https://pantheon.myjetbrains.com/youtrack/issue/PNTN-79

Я думаю нереально успеть пофиксить эти баги до турнира, поэтому лучше использовать очки пришедшие с тенхи. Позже я займусь этими тасками и всё поправлю.