### PR TITLE
Online tournament fixes

### DIFF
--- a/Mimir/data/migrations/20180407082913_ignore_seating_flag.php
+++ b/Mimir/data/migrations/20180407082913_ignore_seating_flag.php
@@ -1,0 +1,14 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class IgnoreSeatingFlag extends AbstractMigration
+{
+
+    public function change()
+    {
+        $this->table('event_registered_players')
+            ->addColumn('ignore_seating', 'integer', ['default' => 0])
+            ->save();
+    }
+}

--- a/Mimir/data/migrations/20180407082913_ignore_seating_flag.php
+++ b/Mimir/data/migrations/20180407082913_ignore_seating_flag.php
@@ -9,6 +9,7 @@ class IgnoreSeatingFlag extends AbstractMigration
     {
         $this->table('event_registered_players')
             ->addColumn('ignore_seating', 'integer', ['default' => 0])
+            ->addIndex('ignore_seating', ['name' => 'registered_players_ignore'])
             ->save();
     }
 }

--- a/Mimir/src/primitives/PlayerRegistration.php
+++ b/Mimir/src/primitives/PlayerRegistration.php
@@ -35,7 +35,8 @@ class PlayerRegistrationPrimitive extends Primitive
         'event_id'      => '_eventId',
         'player_id'     => '_playerId',
         'auth_token'    => '_token',
-        'local_id'      => '_localId'
+        'local_id'      => '_localId',
+        'ignore_seating' => '_ignoreSeating',
     ];
 
     protected function _getFieldsTransforms()
@@ -45,7 +46,8 @@ class PlayerRegistrationPrimitive extends Primitive
             '_eventId' => $this->_integerTransform(),
             '_token' => $this->_stringTransform(),
             '_playerId' => $this->_integerTransform(),
-            '_localId' => $this->_integerTransform(true)
+            '_localId' => $this->_integerTransform(true),
+            '_ignoreSeating' => $this->_integerTransform(),
         ];
     }
 
@@ -70,6 +72,10 @@ class PlayerRegistrationPrimitive extends Primitive
      * @var int
      */
     protected $_localId;
+    /**
+     * @var int
+     */
+    protected $_ignoreSeating;
 
     protected function _create()
     {
@@ -138,6 +144,14 @@ class PlayerRegistrationPrimitive extends Primitive
     public function getLocalId()
     {
         return $this->_localId;
+    }
+
+    /**
+     * @return int
+     */
+    public function getIgnoreSeating()
+    {
+        return $this->_ignoreSeating;
     }
 
     /**
@@ -249,6 +263,18 @@ class PlayerRegistrationPrimitive extends Primitive
         return array_map(function (PlayerRegistrationPrimitive $p) {
             return ['id' => $p->_playerId, 'local_id' => $p->_localId];
         }, self::_findBy($db, 'event_id', [$eventId]));
+    }
+
+    public static function findIgnoredPlayersIdsByEvent(IDb $db, $eventId)
+    {
+        $result = $db->table(static::$_table)
+            ->where('event_id', $eventId)
+            ->where('ignore_seating', 1)
+            ->findArray();
+
+        return array_map(function ($p) {
+            return $p['player_id'];
+        }, $result);
     }
 
     /**

--- a/Rheda/src/templates/PlayerEnrollment.handlebars
+++ b/Rheda/src/templates/PlayerEnrollment.handlebars
@@ -29,11 +29,13 @@
 {{_t 'Note: if a player is already added to the rating, adding him again will result in reissuing his PIN code.'}}
 <table class="table table-condensed table-stripped">
     <tr>
+        <th>ID</th>
         <th>{{_t 'Player'}}</th>
         <th>{{_t 'Admin actions'}}</th>
     </tr>
 {{#everybody}}
     <tr>
+        <td>{{id}}</td>
         <td>{{display_name}}</td>
         <td>
             <form action="" method="post">


### PR DESCRIPTION
1. Добавил новый флаг ignore_seating. По этому флагу рассадка будет исключать игрока из рассадки. Это будет нужно только если во время турнира кто-нибудь ливнёт и его место займёт бот.
2. Раньше если в турнире были игроки с играми и игроки без игр рассадка генерировалась без последних. Я это пофиксил и теперь рассадка будет генерироваться для всех игроков, как уже игравших так и новых. Это опять пригодится только для онлайн турниров и только если кто-нибудь ливнет и на его место сядет бот.
3. На страницу добавления игроков добавил отображение id игрока. В прошлый раз мне приходилось через инспектор страницы выдирать айдишники, было не очень удобно.