### PR TITLE
Исправления ошибок в агрегированных эвентах

### DIFF
--- a/Mimir/src/models/EventRatingTable.php
+++ b/Mimir/src/models/EventRatingTable.php
@@ -97,7 +97,6 @@ class EventRatingTableModel extends Model
             $playersHistoryItemsCombined = array_merge($playersHistoryItemsCombined, $playersHistoryItems);
         }
 
-        /*  */
         $playerHistoryItemsSummed = [];
         foreach ($playerItems as $player) {
             $itemsByPlayer = array_values(
@@ -130,7 +129,7 @@ class EventRatingTableModel extends Model
             $playerHistoryItemsSummed = array_reverse($playerHistoryItemsSummed);
         }
 
-        if ($mainEvent->getSortByGames()) {
+        if (count($eventList) > 1 || $mainEvent->getSortByGames()) {
             $this->_stableSort(
                 $playerHistoryItemsSummed,
                 function (PlayerHistoryPrimitive $el1, PlayerHistoryPrimitive $el2) {

--- a/Mimir/src/models/EventRatingTable.php
+++ b/Mimir/src/models/EventRatingTable.php
@@ -129,6 +129,7 @@ class EventRatingTableModel extends Model
             $playerHistoryItemsSummed = array_reverse($playerHistoryItemsSummed);
         }
 
+        /* Aggregated events are always sorted by games to move substitute players to the bottom of the table. */
         if (count($eventList) > 1 || $mainEvent->getSortByGames()) {
             $this->_stableSort(
                 $playerHistoryItemsSummed,

--- a/Mimir/src/primitives/PlayerHistory.php
+++ b/Mimir/src/primitives/PlayerHistory.php
@@ -332,6 +332,7 @@ class PlayerHistoryPrimitive extends Primitive
             ->_updateAvgPlaceAndGamesCount($place);
     }
 
+    /* FIXME: change this function to take array of histories as input. */
     /**
      * Create a new history item which is a sum of two other history items.
      *
@@ -348,7 +349,8 @@ class PlayerHistoryPrimitive extends Primitive
         return (new self($his1->_db))
             ->setPlayer($his1->getPlayer())
             ->setSession($his1->getSession())
-            ->_setAvgPlace(($his1->getAvgPlace() + $his2->getAvgPlace()) / 2)
+            ->_setAvgPlace(($his1->getAvgPlace() * $his1->getGamesPlayed() + $his2->getAvgPlace() * $his2->getGamesPlayed())
+                    / ($his1->getGamesPlayed() + $his2->getGamesPlayed()))
             ->_setGamesPlayed($his1->getGamesPlayed() + $his2->getGamesPlayed())
             ->_setRating($his1->getRating() + $his2->getRating());
     }


### PR DESCRIPTION
1. Исправлен подсчет среднего. Там по-хорошему, нужно всю функцию отрефакторить, чтобы она сразу с массивом работала, а не вызывалась для каждой пары, но я бы лучше это сделал в следующих патчах, когда новую статистику буду добавлять.
2. Для агрегированных эвентов игроки теперь отсортированы по числу игр.