### PR TITLE
fixes for db ports in phinx.yml files

### DIFF
--- a/Frey/phinx.yml
+++ b/Frey/phinx.yml
@@ -11,7 +11,7 @@ environments:
         name: %%PHINX_DBPROD_FREY_NAME%%
         user: %%PHINX_DBPROD_FREY_USER%%
         pass: %%PHINX_DBPROD_FREY_PASS%%
-        port: 5432
+        port: %%PHINX_DB_FREY_PORT%%
         charset: utf8
 
     staging:
@@ -20,7 +20,7 @@ environments:
         name: %%PHINX_DB_FREY_NAME%%
         user: %%PHINX_DB_FREY_USER%%
         pass: %%PHINX_DB_FREY_PASS%%
-        port: 5432
+        port: %%PHINX_DB_FREY_PORT%%
         charset: utf8
 
     testing:

--- a/Mimir/phinx.yml
+++ b/Mimir/phinx.yml
@@ -11,7 +11,7 @@ environments:
         name: %%PHINX_DBPROD_NAME%%
         user: %%PHINX_DBPROD_USER%%
         pass: %%PHINX_DBPROD_PASS%%
-        port: 5432
+        port: %%PHINX_DB_PORT%%
         charset: utf8
 
     staging:
@@ -20,7 +20,7 @@ environments:
         name: %%PHINX_DB_NAME%%
         user: %%PHINX_DB_USER%%
         pass: %%PHINX_DB_PASS%%
-        port: 5432
+        port: %%PHINX_DB_PORT%%
         charset: utf8
 
     testing:


### PR DESCRIPTION
There are a few places in the files which do not use environment variables, but instead use hard-coded values. I'm just piloting a couple of small changes first, to see if I've understood the situation correctly, and to see whether these changes are useful to you. There are more of these to come if you like them.