### PR TITLE
Hotfix/oka calculation error fix

### DIFF
--- a/Mimir/src/Ruleset.php
+++ b/Mimir/src/Ruleset.php
@@ -128,7 +128,7 @@ abstract class Ruleset
     public function oka($place)
     {
         if ($place === 1) {
-            return ((static::$_ruleset['oka'])*0,75)) ;
+            return ((static::$_ruleset['oka'])*0.75) ;
         } else {
             return -(static::$_ruleset['oka'] / 4);
         }

--- a/Mimir/src/Ruleset.php
+++ b/Mimir/src/Ruleset.php
@@ -120,10 +120,15 @@ abstract class Ruleset
         return static::$_ruleset['uma'];
     }
 
+    /**
+     * oka is an ante every player pays upfront, and the winner takes its all.
+     * so if oka is 20000, every player puts 5000 in the "oka-pot" and the
+     * gets it all, so he profits 15000 as he payed 5000 himself too.
+     */
     public function oka($place)
     {
         if ($place === 1) {
-            return static::$_ruleset['oka'];
+            return ((static::$_ruleset['oka'])*0,75)) ;
         } else {
             return -(static::$_ruleset['oka'] / 4);
         }


### PR DESCRIPTION
I discovered a bug in the oka calculation when using pantheon for our club games,
for our east only games we use uma and okay, and we noticed that after a session completed the first ranked player always had 5000 points too many with the following settings in our config/ruleset file for our clubgames
`       'oka'                   => 20000,
      `
After looking at the oka function i noticed that with how it is calculated now, first gets the whole oka sum (20k) but only 3x5k is subtracted from the three loosing players.
As oka works like an ante, every player needs to pay 1/4th of the oka beforehand, and the winner gets it all.
With the change now in place calculation with uma and oka first ranked player only gets 3/4th of the whole uma and the score is correct.
See also http://arcturus.su/wiki/Oka_and_uma if it is unclear.

Kind regards, Mike