### PR TITLE
[PNTN-215] Fix a bug with wrong number of games on the player graph.

### DIFF
--- a/Mimir/src/models/PlayerStat.php
+++ b/Mimir/src/models/PlayerStat.php
@@ -101,7 +101,7 @@ class PlayerStatModel extends Model
                     return $rating;
                 },
                 $games
-            )
+            ), 'is_numeric'
         );
         array_unshift($ratingHistory, $event->getRuleset()->startRating());
         return $ratingHistory;

--- a/Mimir/src/models/PlayerStat.php
+++ b/Mimir/src/models/PlayerStat.php
@@ -101,7 +101,8 @@ class PlayerStatModel extends Model
                     return $rating;
                 },
                 $games
-            ), 'is_numeric'
+            ),
+            'is_numeric'
         );
         array_unshift($ratingHistory, $event->getRuleset()->startRating());
         return $ratingHistory;


### PR DESCRIPTION
Игрок получит -30100 за первый ханчан и +30100 за второй. В итоге рейтинг стал равен нулю после двух игр.

Функция `array_filter` по дефолту выкидывает нулевые значения из массива, поэтому одной игры и не было на графике. `callback=is_numeric` пофиксил баг.