### PR TITLE
[PNTN-187] Display yakuman icon correctly on the double ron screen

### DIFF
--- a/Tyr/src/app/components/screen-yaku-select/template.html
+++ b/Tyr/src/app/components/screen-yaku-select/template.html
@@ -76,6 +76,6 @@
     [class.selected]="user.id === this.state.getCurrentMultiRonUser()"
   >
     <div class="name">{{user.displayName}}</div>
-    <div class="score">{{han(user.id)}}<span *ngIf="showFuOf(user.id)">/{{this.state.getFuOf(user.id)}}</span></div>
+    <div class="score">{{han(user.id) | yakuman}}<span *ngIf="showFuOf(user.id)">/{{this.state.getFuOf(user.id)}}</span></div>
   </div>
 </div>


### PR DESCRIPTION
Было:
![image](https://user-images.githubusercontent.com/475367/69006910-2da58c80-0971-11ea-92fc-e818334966dc.png)

Стало:
![image](https://user-images.githubusercontent.com/475367/69006901-00f17500-0971-11ea-8c8e-a3180559fff2.png)
