### PR TITLE
Fix regression after static analyzer fixes

### DIFF
--- a/Mimir/config/index.php
+++ b/Mimir/config/index.php
@@ -49,7 +49,7 @@ return array_merge([
 
     // ---------- not intended for local override! ------------
     'api' => [
-        'version_major' => 1, // do not change this! Update your setup if version mismatches.
-        'version_minor' => 0
+        'version_major' => '1', // do not change this! Update your setup if version mismatches.
+        'version_minor' => '0'
     ]
 ], $locals);

--- a/Mimir/data/seeds/ClubEventSeeder.php
+++ b/Mimir/data/seeds/ClubEventSeeder.php
@@ -132,8 +132,8 @@ class ClubEventSeeder extends AbstractSeed
             'verbose'   => false,
             'verboseLog' => '',
             'api' => [
-                'version_major' => 1,
-                'version_minor' => 0
+                'version_major' => '1',
+                'version_minor' => '0'
             ]
         ]);
 

--- a/Mimir/data/seeds/TournamentSeeder.php
+++ b/Mimir/data/seeds/TournamentSeeder.php
@@ -130,8 +130,8 @@ class TournamentSeeder extends AbstractSeed
             'verbose'   => false,
             'verboseLog' => '',
             'api' => [
-                'version_major' => 1,
-                'version_minor' => 0
+                'version_major' => '1',
+                'version_minor' => '0'
             ]
         ]);
 

--- a/Mimir/tests/util/config.php
+++ b/Mimir/tests/util/config.php
@@ -34,8 +34,8 @@ return [
     'trackerUrl' => null,
     'freyUrl' => '__mock__',
     'api' => [
-        'version_major' => 1,
-        'version_minor' => 0
+        'version_major' => '1',
+        'version_minor' => '0'
     ],
     'testing_token' => '198vdsh904hfbnkjv98whb2iusvd98b29bsdv98svbr9wghj',
 ];


### PR DESCRIPTION
Mimir возвращал `X-Api-Version: 0.0` в ответе из-за того что `$this->_config->getStringValue('api.version_major')` делал строку '0' из int 1.

Rheda проверял что major version 0.0 не совпадает с 1.0 (из конфига Rheda) и падал.