### PR TITLE
bugfix: Disallow players to start a new game manually in preseated tournament

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,4 +56,5 @@ jobs:
         run: make prod_build_ratatosk
 
       - name: Push prod build to repo
+        if: github.repository=='MahjongPantheon/pantheon'
         run: ./.tyr-dist-push.sh

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 .c9/
 *.launch
 .settings/
+*.swp
+*.code-workspace
 
 .DS_Store
 Thumbs.db

--- a/.tyr-dist-push.sh
+++ b/.tyr-dist-push.sh
@@ -13,7 +13,7 @@ commit_built() {
 }
 
 upload_files() {
-  git remote add origin-pntn https://${GITHUB_ACTOR}:${INPUT_GITHUB_TOKEN}@github.com/MahjongPantheon/pantheon.git > /dev/null 2>&1
+  git remote add origin-pntn https://${GITHUB_ACTOR}:${INPUT_GITHUB_TOKEN}@github.com/$GITHUB_REPOSITORY.git > /dev/null 2>&1
   git push --quiet --set-upstream origin-pntn master
 }
 

--- a/Tyr/app/components/screens/game-result/GameResultScreen.tsx
+++ b/Tyr/app/components/screens/game-result/GameResultScreen.tsx
@@ -24,7 +24,7 @@ export const GameResultScreen: React.FC<IComponentProps> = props => {
     })
   }
 
-  const canStartGame = !state.gameConfig.autoSeating && !state.isUniversalWatcher && !state.currentSessionHash
+  const canStartGame = !state.gameConfig.autoSeating && !state.isUniversalWatcher && !state.currentSessionHash && !state.gameConfig.isPrescripted
 
   const onCheckClick = useCallback(() => {
     dispatch({ type: GOTO_NEXT_SCREEN });

--- a/Tyr/app/components/screens/home/HomeScreen.tsx
+++ b/Tyr/app/components/screens/home/HomeScreen.tsx
@@ -70,7 +70,7 @@ export class HomeScreen extends React.PureComponent<IComponentProps> {
     return (
       <HomeScreenView
         eventName={playerName}
-        canStartGame={!state.gameConfig.autoSeating && !state.isUniversalWatcher && !state.currentSessionHash}
+        canStartGame={!state.gameConfig.autoSeating && !state.isUniversalWatcher && !state.currentSessionHash && !state.gameConfig.isPrescripted}
         hasStartedGame={!!state.currentSessionHash && state.gameOverviewReady}
         hasPrevGame={!state.isUniversalWatcher /*&& state.lastResults !== undefined*/}
         canSeeOtherTables={true}

--- a/Tyr/app/interfaces/local.ts
+++ b/Tyr/app/interfaces/local.ts
@@ -96,6 +96,7 @@ export interface LGameConfig {
   eventStatHost: string;
   withAtamahane: boolean;
   autoSeating: boolean;
+  isPrescripted: boolean;
   rulesetTitle: string;
   tonpuusen: boolean;
   startRating: number;

--- a/Tyr/app/interfaces/remote.ts
+++ b/Tyr/app/interfaces/remote.ts
@@ -110,6 +110,7 @@ export interface RGameConfig {
   eventTitle: string;
   withAtamahane: boolean;
   autoSeating: boolean;
+  isPrescripted: boolean;
   rulesetTitle: string;
   eventStatHost: string;
   tonpuusen: boolean;

--- a/Tyr/app/services/formatters.ts
+++ b/Tyr/app/services/formatters.ts
@@ -125,6 +125,7 @@ export function gameConfigFormatter(config: RGameConfig): LGameConfig {
     eventTitle: config.eventTitle,
     withAtamahane: !!config.withAtamahane,
     autoSeating: !!config.autoSeating,
+    isPrescripted: !!config.isPrescripted,
     rulesetTitle: config.rulesetTitle,
     eventStatHost: environment.guiFix(config.eventStatHost),
     tonpuusen: !!config.tonpuusen,


### PR DESCRIPTION
- For tournaments with preseating, a player was able to create a new game before a round was started by admin, and in the process breaking the admin interface.
A manual cleanup of the session in the db was necessary to continue with the tournament.
I added an additional check in Tyr, so the new game button is not displayed when isPrescripted is set in gameConfig.

- Github actions where failing on forks as the repository was hardcoded in the push command.
I added an if clause, only allowing build files to be pushed on main repo.

- Added .swp(temporary vim files)  and vscode workspace files to .gitignore.