### PR TITLE
Fix float rounding in averageDotaCount field

### DIFF
--- a/Rheda/src/controllers/PersonalStats.php
+++ b/Rheda/src/controllers/PersonalStats.php
@@ -162,7 +162,7 @@ class PersonalStats extends Controller
                     'riichiWon'            => $data['riichi_summary']['riichi_won'],
                     'riichiLost'           => $data['riichi_summary']['riichi_lost'],
                     'riichiTotal'          => $riichiTotal,
-                    'averageDoraCount'     => $data['dora_stat']['average'],
+                    'averageDoraCount'     => round($data['dora_stat']['average'], 2),
                     'doraCount'            => $data['dora_stat']['count'],
 
                     'pointsWon'            => $data['win_summary']['points_won'],


### PR DESCRIPTION
Looks like somewhere inside this number is converted from/to float/double (can't say exactly), and ends up begin shown as 0.20000000298023 instead of 0.2

Must be here in DoraCount.php:

```
    /**
     * Generated from protobuf field <code>float average = 2;</code>
     * @param float $var
     * @return $this
     */
    public function setAverage($var)
    {
        GPBUtil::checkFloat($var);
        $this->average = $var;

        return $this;
    }
```