### PR TITLE
[Hermod fix] Fixing Hermod config, adding example for relayhost

### DIFF
--- a/Env/.env.example.production
+++ b/Env/.env.example.production
@@ -62,3 +62,10 @@ VITE_ADMIN_EMAIL=me@ctizen.dev
 VITE_MIMIR_URL_SSR=http://mimir
 VITE_FREY_URL_SSR=http://frey
 VITE_HUGIN_URL_SSR=http://hugin
+
+# Using a relayhost(also called smarthost) with Hermod is possible by setting the below variables
+# refer to https://github.com/hmriit/docker-postfix-dkim for more options
+
+#RELAYHOST=mail.example.com:587
+#RELAYHOST_PASSWORD=mailpassword
+#RELAYHOST_USERNAME=relayuser@example.com

--- a/Hermod/scripts/common-run.sh
+++ b/Hermod/scripts/common-run.sh
@@ -103,7 +103,7 @@ postfix_setup_relayhost() {
 		if [ -n "$RELAYHOST_USERNAME" ] && [ -n "$RELAYHOST_PASSWORD" ]; then
 			echo -e " using username ${emphasis}$RELAYHOST_USERNAME${reset} and password ${emphasis}(redacted)${reset}."
 			echo "$RELAYHOST $RELAYHOST_USERNAME:$RELAYHOST_PASSWORD" >> /etc/postfix/sasl_passwd
-			postmap hash:/etc/postfix/sasl_passwd
+			postmap lmdb:/etc/postfix/sasl_passwd
 			postconf -e "smtp_sasl_auth_enable=yes"
 			postconf -e "smtp_sasl_password_maps=lmdb:/etc/postfix/sasl_passwd"
 			postconf -e "smtp_sasl_security_options=noanonymous"


### PR DESCRIPTION
Added example configuration to Env/.prod.example.production to use arelayhost with hermod instead of directly sending mails.
Fixed a deprecated configuration in common_run.sh in hermod container, that broke the container when starting with relayhost_username and relayhost_password.
See:
https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.13.0#Deprecation_of_Berkeley_DB_.28BDB.29