### PR TITLE
Sigrun fix adding online games

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,9 @@ on:
 jobs:
   buildContainers:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
+    if: |
+      github.ref == 'refs/heads/master' &&
+      github.repository == 'MahjongPantheon/pantheon'
     steps:
       - uses: actions/checkout@v2
 

--- a/Sigrun/src/components/AppHeader.tsx
+++ b/Sigrun/src/components/AppHeader.tsx
@@ -109,7 +109,7 @@ export function AppHeader({ dark, toggleColorScheme, toggleDimmed, saveLang }: A
   const [onlineError, setOnlineError] = useState<string | null>(null);
   const api = useApi();
   const tryAddOnline = () => {
-    if (!onlineLink.match(/^https?:\/\/[^\/]+\/\d\/\?log=\d+gm-\d+-\d+-[0-9a-f]+/i)) {
+    if (!onlineLink.match(/^https?:\/\/[^\/]+\/\d\/\?log=\d+gm-[0-9a-f]+-\d+-[0-9a-f]+/i)) {
       setOnlineError(i18n._t('Replay link is invalid. Please check if you copied it correctly'));
     } else {
       setOnlineError(null);


### PR DESCRIPTION
Two commits in this PR:

1. Changes to regex for url check:

   - tenhou logs can have format like this
     http://tenhou.net/0/?log=2023081506gm-000b-4302-96724ac0&tw=0
     where the part after gm-XXXX is not strictly numbers.

   - Allow http and https as tenhou log links are http mostly.


2. Adding conditional in buildContainers workflow to only run it on "MahongPantheon/pantheon" 
   and not on forks, as the workflow will fail because of missing credentials for the container         repository