### PR TITLE
Fix an issue with multiple events data loading

### DIFF
--- a/Mimir/src/controllers/Events.php
+++ b/Mimir/src/controllers/Events.php
@@ -327,12 +327,12 @@ class EventsController extends Controller
      */
     public function getEventsById($ids)
     {
-        $this->_log->info('Listing events by id [' . implode($ids) . ']');
+        $this->_log->info('Listing events by ids [' . implode(", ", $ids) . ']');
         $data = [];
         if (!empty($ids)) {
             $data = (new EventModel($this->_ds, $this->_config, $this->_meta))->getEventsById($ids);
         }
-        $this->_log->info('Successfully listed events by id [' . implode($ids) . ']');
+        $this->_log->info('Successfully listed events by ids [' . implode(", ", $ids) . ']');
         return $data;
     }
 

--- a/Sigrun/src/pages/RatingTable.tsx
+++ b/Sigrun/src/pages/RatingTable.tsx
@@ -83,12 +83,13 @@ export const RatingTable: React.FC<{
   const DataCmp = largeScreen ? Group : Stack;
   const auth = useContext(authCtx);
   const globals = useContext(globalsCtx);
+  const eventIds = eventId.split('.').map((x) => parseInt(x));
   const [players, , playersLoading] = useIsomorphicState(
     [],
     'RatingTable_event_' + eventId + order + orderBy + minGamesSelector,
     () =>
       api.getRatingTable(
-        parseInt(eventId, 10),
+        eventIds,
         order ?? 'desc',
         orderBy === 'team' ? 'rating' : orderBy ?? 'rating',
         minGamesSelector === 'min'

--- a/Sigrun/src/services/api.ts
+++ b/Sigrun/src/services/api.ts
@@ -130,7 +130,7 @@ export class ApiService {
   }
 
   getRatingTable(
-    eventId: number,
+    eventIds: number[],
     order: 'asc' | 'desc',
     orderBy: 'name' | 'rating' | 'avg_place' | 'avg_score',
     onlyMinGames: boolean
@@ -139,7 +139,7 @@ export class ApiService {
       method: 'GetRatingTable',
     });
     return GetRatingTable(
-      { eventIdList: [eventId], order, orderBy, onlyMinGames },
+      { eventIdList: eventIds, order, orderBy, onlyMinGames },
       this._clientConfMimir
     ).then((r) => r.list);
   }


### PR DESCRIPTION
Allow to combine data from multiple events to the single table, for example: https://rating.riichimahjong.org/event/106.254/order/team