### PR TITLE
Fix unicode-range for Korean font-face

### DIFF
--- a/Tyr/public/font-ko.css
+++ b/Tyr/public/font-ko.css
@@ -4,7 +4,9 @@
   font-weight: 300;
   font-style: normal;
   font-display: swap;
-  unicode-range: U+AC00-D7A3;
+  unicode-range:
+    U+AC00-D7A3,
+    U+3130-318F U+1100-11FF;
 }
 @font-face {
   font-family: IBM Plex Sans;
@@ -12,5 +14,7 @@
   font-weight: 600;
   font-style: normal;
   font-display: swap;
-  unicode-range: U+AC00-D7A3;
+  unicode-range:
+    U+AC00-D7A3,
+    U+3130-318F U+1100-11FF;
 }

--- a/Tyr/public/font-ko.css
+++ b/Tyr/public/font-ko.css
@@ -4,7 +4,7 @@
   font-weight: 300;
   font-style: normal;
   font-display: swap;
-  unicode-range: U+3000-30FF, U+FF00-FFEF, U+4E00-9FAF;
+  unicode-range: U+AC00-D7A3;
 }
 @font-face {
   font-family: IBM Plex Sans;
@@ -12,5 +12,5 @@
   font-weight: 600;
   font-style: normal;
   font-display: swap;
-  unicode-range: U+3000-30FF, U+FF00-FFEF, U+4E00-9FAF;
+  unicode-range: U+AC00-D7A3;
 }


### PR DESCRIPTION
Updated Hangul(Korean writing) unicode-range.

```css
  unicode-range:
    U+AC00-D7A3,
    U+3130-318F U+1100-11FF;
```