### PR TITLE
fix: add minBarLength default for chart.js

### DIFF
--- a/Sigrun/app/components/BarGraph.tsx
+++ b/Sigrun/app/components/BarGraph.tsx
@@ -22,6 +22,5 @@ ChartJS.register(
 );
 ChartJS.defaults.font.size = 16;
 ChartJS.defaults.font.family = '"PT Sans Narrow", Arial';
-ChartJS.defaults.datasets.bar.minBarLength = 25;
 
 export default BarGraph;

--- a/Sigrun/app/components/BarGraph.tsx
+++ b/Sigrun/app/components/BarGraph.tsx
@@ -22,5 +22,6 @@ ChartJS.register(
 );
 ChartJS.defaults.font.size = 16;
 ChartJS.defaults.font.family = '"PT Sans Narrow", Arial';
+ChartJS.defaults.datasets.bar.minBarLength = 25;
 
 export default BarGraph;

--- a/Sigrun/app/components/YakuGraph.tsx
+++ b/Sigrun/app/components/YakuGraph.tsx
@@ -73,7 +73,7 @@ export const YakuGraph = ({ yakuStat }: { yakuStat?: YakuStat[] }) => {
   return (
     <div style={{ position: 'relative', height: `${yakuStatsHeight}px` }}>
       <BarGraph
-        data={{ datasets: [{ data: yakuStats }] }}
+        data={{ datasets: [{ data: yakuStats, minBarLength: 25 }] }}
         options={{
           maintainAspectRatio: false,
           backgroundColor: isDark ? theme.colors.blue[8] : theme.colors.blue[3],


### PR DESCRIPTION
Решает проблему узких баров на графиках BarGraph.tsx с кол-вом близким к нулю, по которым сложно попасть пальцем на мобильных устройствах, например кол-во собранных яку в YakuGraph.tsx:
![image](https://github.com/user-attachments/assets/ef1a0e13-8ce3-4126-9388-7fe3c127b36c)
