### PR TITLE
fix: add extra info to y-axis labels for YakuGraph.tsx

### DIFF
--- a/Sigrun/app/components/YakuGraph.tsx
+++ b/Sigrun/app/components/YakuGraph.tsx
@@ -60,20 +60,20 @@ export const YakuGraph = ({ yakuStat }: { yakuStat?: YakuStat[] }) => {
 
   const yakuStats = [...yaku.entries()]
     .map(([key, value]) => {
-      return { x: value, y: yakuNameMap.get(key) };
+      return { x: value, y: yakuNameMap.get(key) + ` (${value})` };
     })
     .filter((v) => v.x > 0)
     .sort((a, b) => b.x - a.x);
 
   if (totalYakuhai > 0) {
-    yakuStats.push({ x: totalYakuhai, y: i18n._t('Yakuhai: total') });
+    yakuStats.push({ x: totalYakuhai, y: i18n._t('Yakuhai: total') + ` (${totalYakuhai})` });
   }
 
   const yakuStatsHeight = 40 + 24 * yakuStats.length;
   return (
     <div style={{ position: 'relative', height: `${yakuStatsHeight}px` }}>
       <BarGraph
-        data={{ datasets: [{ data: yakuStats, minBarLength: 25 }] }}
+        data={{ datasets: [{ data: yakuStats }] }}
         options={{
           maintainAspectRatio: false,
           backgroundColor: isDark ? theme.colors.blue[8] : theme.colors.blue[3],
@@ -82,7 +82,11 @@ export const YakuGraph = ({ yakuStat }: { yakuStat?: YakuStat[] }) => {
           font: { size: 16, family: '"PT Sans Narrow", Arial' },
           plugins: {
             legend: { display: false },
+            tooltip: {
+              enabled: false,
+            },
           },
+          events: [],
           indexAxis: 'y',
           // grouped: false,
           scales: {


### PR DESCRIPTION
Другой костылик, по которому информация о кол-ве собранных яку в YakuGraph.tsx отображается в лейблах по оси Y, например так:
![image](https://github.com/user-attachments/assets/53debf30-f1a6-4eb6-b33c-7eb0f7422d86)

А также: 
- упраздняется предыдущий костыль
- отключаются тултипы, т.к. они становятся избыточными
- отключаются hover-эффекты, чтобы не отвлекать внимание от графика