### PR TITLE
fix: add colorSchemeManager to control vital toggleTheme storage values [800]

### DIFF
--- a/Sigrun/app/Layout.tsx
+++ b/Sigrun/app/Layout.tsx
@@ -38,6 +38,7 @@ import { AddOnlineReplayModal } from './components/AddOnlineReplayModal';
 import { useRoute } from 'wouter';
 import { fontLoader } from './helpers/fontLoader';
 import { getThemeOptions } from 'helpers/theme';
+import { colorSchemeManager } from 'helpers/colorSchemeManager';
 import '@mantine/core/styles.css';
 import './App.css';
 
@@ -148,7 +149,10 @@ export function Layout({ children }: { children: ReactNode }) {
   };
 
   return (
-    <MantineProvider theme={useDimmed ? dimmedTheme : defaultTheme}>
+    <MantineProvider
+      theme={useDimmed ? dimmedTheme : defaultTheme}
+      colorSchemeManager={colorSchemeManager(storage)}
+    >
       <MantineEmotionProvider>
         <AnalyticsProvider>
           <modalsCtx.Provider value={{ onlineModalShown, showOnlineModal, hideOnlineModal }}>

--- a/Sigrun/app/helpers/colorSchemeManager.ts
+++ b/Sigrun/app/helpers/colorSchemeManager.ts
@@ -1,0 +1,43 @@
+import { MantineColorScheme, MantineColorSchemeManager } from '@mantine/core';
+import { Storage } from '../../../Common/storage';
+
+// See also Tyr/app/services/themes.ts - we use names from there to sync themes
+const themeToLocal: (theme?: string | null) => string = (theme): MantineColorScheme => {
+  return ({
+    day: 'light',
+    night: 'dark',
+  }[theme ?? 'day'] ?? 'light') as MantineColorScheme;
+};
+
+const themeFromLocal: (theme?: 'light' | 'dark' | 'auto') => string = (theme) => {
+  return (
+    {
+      light: 'day',
+      dark: 'night',
+      auto: 'day',
+    }[theme ?? 'light'] ?? 'day'
+  );
+};
+
+export function colorSchemeManager(storage: Storage): MantineColorSchemeManager {
+  return {
+    get: (defaultValue): MantineColorScheme => {
+      const themeValue = storage.getTheme();
+      const currentThemeValue = themeValue ? themeToLocal(themeValue) : defaultValue;
+
+      return currentThemeValue as MantineColorScheme;
+    },
+
+    set: (value) => {
+      storage.setTheme(themeFromLocal(value));
+    },
+
+    subscribe: () => {},
+
+    unsubscribe: () => {},
+
+    clear: () => {
+      storage.deleteTheme();
+    },
+  };
+}


### PR DESCRIPTION
Used [MantineColorSchemeManager](https://mantine.dev/theming/color-schemes/#color-scheme-manager) from v7 to support custom implementation of storing toggleTheme values from v6 