### PR TITLE
fix: shorten datetime (without seconds) in GameListing to take up less space

### DIFF
--- a/Sigrun/app/components/GameListing.tsx
+++ b/Sigrun/app/components/GameListing.tsx
@@ -63,6 +63,7 @@ export const GameListing: React.FC<GameListingProps> = ({
   const DataCmp = largeScreen ? Group : Stack;
   const winds = ['東', '南', '西', '北'];
   const isDark = useMantineColorScheme().colorScheme === 'dark';
+  const dateTime = game.date?.slice(0, -3) ?? '';
 
   const outcomes = { ron: 0, tsumo: 0, draw: 0, chombo: 0, nagashi: 0 };
   const yakitori = withYakitori
@@ -126,7 +127,7 @@ export const GameListing: React.FC<GameListingProps> = ({
       </div>
       {/* Players list */}
       <Stack style={{ flexGrow: 0, minWidth: '300px' }}>
-        <Text>{game.date}</Text>
+        <Text>{dateTime}</Text>
         {game.finalResults.map((result, idx) => (
           <Group key={`pl_${idx}`} style={{ alignItems: 'flex-start' }}>
             <Badge


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ae14fce0-2b2e-4327-aa7b-c8ad76fe04e4)
