### PR TITLE
fix: resolve mantine List.Items overlaps with surroundings issue

### DIFF
--- a/Sigrun/app/App.css
+++ b/Sigrun/app/App.css
@@ -65,3 +65,9 @@ body {
   background-size: auto 16px;
   background-repeat: repeat-x;
 }
+
+/* Hack to make mantine's List.Items respect container's width and do not overlap with surroundings */
+.mantine-AppShell-root .mantine-List-itemWrapper {
+  display: inline;
+  white-space: normal;
+}

--- a/Sigrun/app/components/AppFooter.tsx
+++ b/Sigrun/app/components/AppFooter.tsx
@@ -25,7 +25,7 @@ import { EventType } from '../clients/proto/atoms.pb';
 
 export function AppFooter() {
   const i18n = useI18n();
-  const largeScreen = useMediaQuery('(min-width: 640px)');
+  const largeScreen = useMediaQuery('(min-width: 768px)');
   const globals = useContext(globalsCtx);
 
   return (

--- a/Sigrun/app/components/AppHeader.tsx
+++ b/Sigrun/app/components/AppHeader.tsx
@@ -66,7 +66,7 @@ export function AppHeader({ isLoggedIn, saveLang, toggleDimmed }: AppHeaderProps
   const [location, navigate] = useLocation();
   const auth = useContext(authCtx);
   const [menuOpened, { open: openMenu, close: closeMenu }] = useDisclosure(false);
-  const largeScreen = useMediaQuery('(min-width: 640px)');
+  const largeScreen = useMediaQuery('(min-width: 768px)');
   const veryLargeScreen = useMediaQuery('(min-width: 1024px)');
   const matchedEventId = location.match(/\/event\/([^/]+)\//);
   const isDark = useMantineColorScheme().colorScheme === 'dark';

--- a/Sigrun/app/pages/Achievements.tsx
+++ b/Sigrun/app/pages/Achievements.tsx
@@ -62,6 +62,7 @@ import { Meta } from '../components/Meta';
 import { useContext } from 'react';
 import { authCtx } from '../hooks/auth';
 import { globalsCtx } from '../hooks/globals';
+import { useMediaQuery } from '@mantine/hooks';
 
 enum Achievement {
   BEST_HAND = 'bestHand',
@@ -119,6 +120,7 @@ export const Achievements: React.FC<{ params: { eventId: string } }> = ({
   const auth = useContext(authCtx);
   const globals = useContext(globalsCtx);
   const events = useEvent(eventId);
+  const largeScreen = useMediaQuery('(min-width: 768px)');
   const [achievementsData] = useIsomorphicState(
     null,
     'Achievements_' + eventId,
@@ -706,7 +708,7 @@ export const Achievements: React.FC<{ params: { eventId: string } }> = ({
   }
 
   return (
-    <Container>
+    <Container p={largeScreen ? 'md' : 0}>
       <Meta
         title={`${events?.[0].title} - ${i18n._t('Achievements')} - Sigrun`}
         description={i18n._t('Achievements list for the event "%1" provided by Mahjong Pantheon', [


### PR DESCRIPTION
Issue:
![image](https://github.com/user-attachments/assets/37c5f411-fae1-44dc-8430-ae2f05d24a0f)

Fix:
- Add global class rewriting default mantine/core List.Item styles to reasonable one.
- Groom largeScreen definition in Sigtun and make it unified - 768px